### PR TITLE
Added Rotary Encoder Scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ Tested on the KLOR "SAEGEWERK" variant & RP2040 Pro Micro by SparkFun.
 - Haptic feedback
 - Pixart Paw3204 trackball
 
-other:
-- Encoder is working on the left side
-
 ___
 ## Installation:
 Follow the [KMK firmware TL;DR Quick start guide](http://kmkfw.io/docs/Getting_Started/#tldr-quick-start-guide) or the steps bellow:

--- a/kb.py
+++ b/kb.py
@@ -1,24 +1,53 @@
 import board
 
 from kmk.kmk_keyboard import KMKKeyboard as _KMKKeyboard
+from kmk.scanners.keypad import MatrixScanner
+from kmk.scanners.encoder import RotaryioEncoder
 from kmk.scanners import DiodeOrientation
 
 
 class KMKKeyboard(_KMKKeyboard):
+    def __init__(self):
+        # create and register the scanner(s)
+        self.matrix = [
+            MatrixScanner(
+                # required arguments:
+                column_pins = self.col_pins,
+                row_pins = self.row_pins,
+            ),
+            RotaryioEncoder(
+                pin_a=self.encoder_a,
+                pin_b=self.encoder_b,
+            )
+        ]
     col_pins = (board.A1, board.A0, board.SCK, board.MISO, board.MOSI, board.D21)
     row_pins = (board.D5, board.D6, board.D7, board.D8)
     diode_orientation = DiodeOrientation.COL2ROW
-    encoder_pin_0 = board.A2
-    encoder_pin_1 = board.A3
+    encoder_a = board.A3
+    encoder_b = board.A2
     # NOQA
     # flake8: noqa
     coord_mapping = [
-            1,  2,  3,  4,  5,         29, 28, 27, 26, 25,
-        6,  7,  8,  9, 10, 11,         35, 34, 33, 32, 31, 30,
-       12, 13, 14, 15, 16, 17, 23, 47, 41, 40, 39, 38, 37, 36,
-               19, 20, 21, 22,         46, 45, 44, 43,
+            1,  2,  3,  4,  5,         31, 30, 29, 28, 27,
+        6,  7,  8,  9, 10, 11,         37, 36, 35, 34, 33, 32,
+       12, 13, 14, 15, 16, 17, 23, 49, 43, 42, 41, 40, 39, 38,
+               19, 20, 21, 22,         48, 47, 46, 45,                
+                       24, 25,         51, 50,
     ]
 
+#2)
+#            1,  2,  3,  4,  5,         31, 30, 29, 28, 27,
+#        6,  7,  8,  9, 10, 11,         37, 36, 35, 34, 33, 32,
+#       12, 13, 14, 15, 16, 17,         43, 42, 41, 40, 39, 38,
+#               19, 20, 21, 22, 23, 49, 48, 47, 46, 45,                
+#                       24, 25,         51, 50,
+
+#1)
+#            1,  2,  3,  4,  5,         31, 30, 29, 28, 27,
+#        6,  7,  8,  9, 10, 11,         37, 36, 35, 34, 33, 32,
+#       12, 13, 14, 15, 16, 17,         43, 42, 41, 40, 39, 38,
+#           19, 20, 21, 22, 23,         49, 48, 47, 46, 45,                
+#                       24, 25,         51, 50,
 
 
 

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ from kb import KMKKeyboard
 from kmk.keys import KC
 from kmk.modules.split import Split, SplitType
 from kmk.modules.layers import Layers
-from kmk.modules.encoder import EncoderHandler
 from kmk.extensions.media_keys import MediaKeys 
 
 keyboard = KMKKeyboard()
@@ -33,11 +32,18 @@ LOWER = KC.MO(1)
 # Keymap
 keyboard.keymap = [
     [  
-       #Base        |        |        |        |        |        |        | |        |        |        |        |        |        |        |
-                         KC.Q,    KC.W,    KC.E,    KC.R,    KC.T,                        KC.Y,    KC.U,    KC.I,    KC.O,    KC.P,         \
-               KC.N1,    KC.A,    KC.S,    KC.D,    KC.F,    KC.G,                        KC.H,    KC.J,    KC.K,    KC.L, KC.SCLN, KC.N2,  \
-               KC.N2,    KC.Z,    KC.X,    KC.C,    KC.V,    KC.B, KC.MUTE,   KC.MPLY,    KC.N,    KC.M, KC.COMM,  KC.DOT, KC.SLSH, KC.N3,  \
-                                 KC.N1,   LOWER,   KC.N3,   KC.N4,                       KC.N4,   KC.N3,  KC.SPC,   KC.N1,  
+       #BASE 
+       #     |        |        |        |        |        |        | |        |        |        |        |        |        |        |
+                  KC.Q,    KC.W,    KC.E,    KC.R,    KC.T,                        KC.Y,    KC.U,    KC.I,    KC.O,    KC.P,         \
+        KC.N1,    KC.A,    KC.S,    KC.D,    KC.F,    KC.G,                        KC.H,    KC.J,    KC.K,    KC.L, KC.SCLN, KC.N2,  \
+        KC.N2,    KC.Z,    KC.X,    KC.C,    KC.V,    KC.B, KC.MUTE,   KC.MPLY,    KC.N,    KC.M, KC.COMM,  KC.DOT, KC.SLSH, KC.N3,  \
+                          KC.N1,   LOWER,   KC.N3,   KC.N4,                       KC.N4,   KC.N3,  KC.SPC,   KC.N1,  
+        
+        # Encoders
+        KC.AUDIO_VOL_UP,     #Left side counterclockwise                                                                  
+        KC.AUDIO_VOL_DOWN,   #Left side clockwise 
+        KC.MEDIA_PREV_TRACK, #Right side counterclockwise                                                          
+        KC.MEDIA_NEXT_TRACK, #Right side clockwise 
     ],
     [  
        #LOWER       |        |        |        |        |        |        | |        |        |        |        |        |        |        |
@@ -47,17 +53,6 @@ keyboard.keymap = [
                                  KC.N1, _______,   KC.N3,   KC.N4,                       KC.N4,   KC.N3,  KC.SPC,   KC.N1,  
     ],
 ]
-
-
-# Encoder: Comment this out if you are not using encoders in your build
-encoder_handler = EncoderHandler()
-encoder_handler.pins = ((keyboard.encoder_pin_1, keyboard.encoder_pin_0, None, False),)
-encoder_handler.map = (
-    ((KC.VOLU, KC.VOLD),),  # Encoder function on Base layer
-    ((KC.UP, KC.DOWN),),  # Encoder function on LOWER layer
-)
-
-keyboard.modules.append(encoder_handler)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Added rotary encoder scanners  & keypad MatrixScanner to `kb.py`
- Changed `coord_mapping` in `kb.py`, adding the encoder "key" positions
___
- Changed the keymap in `main.py` accordingly 
- Removed  the old encoder code from `main.py`

tl;dr: encoders are now working in both keyboard sides.
